### PR TITLE
Egen strategi for enhet og miljø

### DIFF
--- a/src/main/java/no/nav/poao_unleash/ApplicationConfig.java
+++ b/src/main/java/no/nav/poao_unleash/ApplicationConfig.java
@@ -14,6 +14,8 @@ import no.nav.poao_unleash.auth.TokenValidator;
 import no.nav.poao_unleash.auth.TokenValidatorImpl;
 import no.nav.poao_unleash.auth.discovery.OidcDiscoveryConfigurationClient;
 import no.nav.poao_unleash.config.EnvironmentProperties;
+import no.nav.poao_unleash.env.NaisEnv;
+import no.nav.poao_unleash.strategies.ByEnhetAndEnvironmentStrategy;
 import no.nav.poao_unleash.strategies.ByEnhetStrategy;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -38,8 +40,8 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public UnleashClient unleashClient(EnvironmentProperties environmentProperties, ByEnhetStrategy byEnhetStrategy) {
-        return new UnleashClientImpl(environmentProperties.getUnleashUrl(), APPLICATION_NAME, List.of(byEnhetStrategy));
+    public UnleashClient unleashClient(EnvironmentProperties environmentProperties, ByEnhetStrategy byEnhetStrategy, ByEnhetAndEnvironmentStrategy byEnhetAndEnvironmentStrategy) {
+        return new UnleashClientImpl(environmentProperties.getUnleashUrl(), APPLICATION_NAME, List.of(byEnhetStrategy, byEnhetAndEnvironmentStrategy));
     }
 
     @Bean
@@ -60,5 +62,10 @@ public class ApplicationConfig {
         return AzureAdTokenClientBuilder.builder()
                 .withNaisDefaults()
                 .buildMachineToMachineTokenClient();
+    }
+
+    @Bean
+    public NaisEnv naisEnv() {
+        return new NaisEnv();
     }
 }

--- a/src/main/java/no/nav/poao_unleash/FeatureController.java
+++ b/src/main/java/no/nav/poao_unleash/FeatureController.java
@@ -42,7 +42,13 @@ public class FeatureController {
     ) {
 
         Optional<String> maybeNavident = Optional.ofNullable(request.getHeader("Authorization"))
-                .map(authHeader -> authHeader.split(" ")[1])
+                .map(authHeader -> {
+                    String[] parts = authHeader.split(" ");
+                    if(parts.length > 1) {
+                        return parts[1];
+                    }
+                    return null;
+                })
                 .flatMap(tokenValidator::validate)
                 .map(claims -> claims.getStringClaim(AAD_NAV_IDENT_CLAIM));
 

--- a/src/main/java/no/nav/poao_unleash/env/NaisEnv.java
+++ b/src/main/java/no/nav/poao_unleash/env/NaisEnv.java
@@ -1,0 +1,23 @@
+package no.nav.poao_unleash.env;
+
+import java.util.Objects;
+
+public class NaisEnv {
+    private final String clusterName;
+
+    public NaisEnv() {
+        this.clusterName = System.getenv("NAIS_CLUSTER_NAME");
+    }
+
+    public boolean isLocal() {
+        return Objects.equals(clusterName, "local");
+    }
+
+    public boolean isDevGCP() {
+        return Objects.equals(clusterName, "dev-gcp");
+    }
+
+    public boolean isProdGCP() {
+        return Objects.equals(clusterName, "prod-gcp");
+    }
+}

--- a/src/main/java/no/nav/poao_unleash/strategies/ByEnhetAndEnvironmentStrategy.java
+++ b/src/main/java/no/nav/poao_unleash/strategies/ByEnhetAndEnvironmentStrategy.java
@@ -6,6 +6,7 @@ import no.finn.unleash.UnleashContext;
 import no.finn.unleash.strategy.Strategy;
 import no.nav.common.client.axsys.AxsysClient;
 import no.nav.common.types.identer.NavIdent;
+import no.nav.poao_unleash.env.NaisEnv;
 import no.nav.poao_unleash.utils.NAVidentUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
@@ -17,16 +18,19 @@ import static java.util.stream.Collectors.toList;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ByEnhetStrategy implements Strategy {
+public class ByEnhetAndEnvironmentStrategy implements Strategy {
 
     static final String PARAM = "valgtEnhet";
+    static final String MILJO_PARAM = "tilgjengeligIProd";
     static final String TEMA_OPPFOLGING = "OPP";
     private final AxsysClient axsysClient;
+
+    private final NaisEnv naisEnv;
 
     @NotNull
     @Override
     public String getName() {
-        return "byEnhet";
+        return "byEnhetAndEnvironment";
     }
 
     @Override
@@ -36,11 +40,15 @@ public class ByEnhetStrategy implements Strategy {
 
     @Override
     public boolean isEnabled(@NotNull Map<String, String> parameters, UnleashContext unleashContext) {
-        return unleashContext.getUserId()
+        boolean enhetValgt = unleashContext.getUserId()
                 .flatMap(currentUserId -> Optional.ofNullable(parameters.get(PARAM))
                         .map(enheterString -> Set.of(enheterString.split(",\\s?")))
                         .map(enabledeEnheter -> !Collections.disjoint(enabledeEnheter, brukersEnheter(currentUserId))))
                 .orElse(false);
+
+        if(!enhetValgt) return false;
+
+        return (naisEnv.isLocal() || naisEnv.isDevGCP()) || Objects.equals(parameters.get(MILJO_PARAM), "true");
     }
 
     private List<String> brukersEnheter(String navIdent) {


### PR DESCRIPTION
Siden vi opererer med samme enhets-id'er i produksjon som i dev kan det være greit å kunne teste enhets-toggler i dev uten å skru på for brukere i produksjon.