### PR TITLE
Fjern mulighetsrommet api

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -44,12 +44,6 @@ spec:
         - application: veilarbportefoljeflatefs
           namespace: obo
           cluster: dev-gcp
-        - application: mulighetsrommet-veileder-flate
-          namespace: team-mulighetsrommet
-          cluster: dev-gcp
-        - application: mr-admin-flate
-          namespace: team-mulighetsrommet
-          cluster: dev-gcp
         - application: amt-tiltaksarrangor-flate
           namespace: amt
           cluster: dev-gcp

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -44,12 +44,6 @@ spec:
         - application: veilarbportefoljeflatefs
           namespace: obo
           cluster: prod-gcp
-        - application: mulighetsrommet-veileder-flate
-          namespace: team-mulighetsrommet
-          cluster: prod-gcp
-        - application: mr-admin-flate
-          namespace: team-mulighetsrommet
-          cluster: prod-gcp
         - application: amt-tiltaksarrangor-flate
           namespace: amt
           cluster: prod-gcp


### PR DESCRIPTION
Team Valp har migrert over til egen Unleash-instans så rydder bort våre tilganger.